### PR TITLE
Allow spaces before literary comment directives.

### DIFF
--- a/pyreport/main.py
+++ b/pyreport/main.py
@@ -417,6 +417,7 @@ def py2commentblocks(string, firstlinenum, options):
             lines = tokencontent.splitlines()
             lines = map(lambda z : z + "\n", lines[:])
             for line in lines:
+                line = line.lstrip()
                 if line[0:3] == "#!/" and reallinenum == 1:
                     # This is a "#!/foobar on the first line, this 
                     # must be an executable call


### PR DESCRIPTION
BUG: When there are some spaces before the rst / latext literary comment line, literary comment doesn't work. This makes impossible to use literary comments inside if () and other conditional statements, subroutines e.t.c.

For example, this statement doesn't work as desired:

if (opts.statistics):
    #! Statistics
    #!-------------------
    ...

This patch fixes that and allows spaces before literary comment directives.

UPD: I found it doesn't work as desired anyway. Now we can add rst comment after If (): statement, for example. But rst line is added to the output file regardless of whether if (): statement was true or not. 

So, my patch doesn't do anything useful.
