### PR TITLE
Fixes for (PDF)LaTeX compilation

### DIFF
--- a/pyreport/main.py
+++ b/pyreport/main.py
@@ -511,6 +511,8 @@ def tex2pdf(filename, options):
         execute("dvips -E %s.dvi -o %s.eps" % (filename, filename))
     elif options.outtype == "pdf":
         if HAVE_PDFLATEX:
+            # Latex should be compiled multiple times for correct toc, links, tables, etc
+            execute( "pdflatex --interaction scrollmode '%s.tex' -output-directory='%s'" %(filename, os.path.dirname(filename)))
             execute( "pdflatex --interaction scrollmode '%s.tex' -output-directory='%s'" %(filename, os.path.dirname(filename)))
         else:
             execute("latex --interaction scrollmode '%s.tex' -output-directory='%s'" %(filename, os.path.dirname(filename)))

--- a/pyreport/main.py
+++ b/pyreport/main.py
@@ -18,7 +18,7 @@ from traceback import format_exc
 import __builtin__ # to override import ! :->
 import platform
 import tokenize
-import token
+import token as pytoken # rename for when python target code uses "token" as variable
 
 # Local imports
 from options import allowed_types, default_options, HAVE_PDFLATEX, \
@@ -397,7 +397,7 @@ def py2commentblocks(string, firstlinenum, options):
             else:
                 last_token = tokendesc[0]
 
-        tokentype = token.tok_name[tokendesc[0]]
+        tokentype = pytoken.tok_name[tokendesc[0]]
         startpos = tokendesc[2][1]
         tokencontent = tokendesc[1]
         if tokendesc[2][0] > linenum:

--- a/pyreport/main.py
+++ b/pyreport/main.py
@@ -511,10 +511,10 @@ def tex2pdf(filename, options):
         execute("dvips -E %s.dvi -o %s.eps" % (filename, filename))
     elif options.outtype == "pdf":
         if HAVE_PDFLATEX:
-            execute( "pdflatex --interaction scrollmode %s.tex -output-directory=%s" %(filename, os.path.dirname(filename)))
+            execute( "pdflatex --interaction scrollmode '%s.tex' -output-directory='%s'" %(filename, os.path.dirname(filename)))
         else:
-            execute("latex --interaction scrollmode %s.tex -output-directory=%s" %(filename, os.path.dirname(filename)))
-            execute("dvips -E %s.dvi -o %s.eps" % (filename, filename))
+            execute("latex --interaction scrollmode '%s.tex' -output-directory='%s'" %(filename, os.path.dirname(filename)))
+            execute("dvips -E '%s.dvi' -o '%s.eps'" % (filename, filename))
             print "Doing pdf %s" % filename
             execute("epstopdf %s.eps" % filename)
 

--- a/pyreport/pyreport.py
+++ b/pyreport/pyreport.py
@@ -51,6 +51,12 @@ def commandline_call():
     else:
         pyfile = open(args[0],"r")
 
+        # fix include path
+        from os.path import dirname, abspath
+        path_of_pyfile = dirname(abspath(args[0]))
+        sys.path.insert(0, path_of_pyfile)
+        print sys.path
+
     # Store the name of the input file for later use
     options.update({'infilename':args[0]})
 


### PR DESCRIPTION
Two bugs where fixed in these commits:

```
* Whitespaces and Brackets in filenames are now escaped correctly
* Latex is compiled multiple times.
```
